### PR TITLE
Using version 0.9.7 of phpQuery-single

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://querylist.cc",
     "require": {
         "PHP":">=5.3.0",
-        "jaeger/phpquery-single": "^0.9.5"
+        "jaeger/phpquery-single": "^0.9.7"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
使用0.9.7版本的phpQuery-single以解决phpQuery.php文件中因写错hltml造成的错误;