### PR TITLE
fixed the tightenco/collect version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "PHP":">=7.0",
         "jaeger/phpquery-single": "^1",
-        "tightenco/collect": "^5",
+        "tightenco/collect": "5.5.27",
         "jaeger/g-http": "^1.1"
     },
     "suggest":{


### PR DESCRIPTION
默认情况下, tightenco/collect自动安装 v5.8以上版本,导致项目致命错误collect() not found in Kernel.php line 37 无法运行.  固定在v5.5.27运行良好.