### PR TITLE
Fix the matching exception

### DIFF
--- a/src/Dom/Query.php
+++ b/src/Dom/Query.php
@@ -125,7 +125,7 @@ class Query
      */
     public function removeHead()
     {
-        $html = preg_replace('/<head.+?>.+<\/head>/is', '<head></head>', $this->html);
+        $html = preg_replace('/(<head>|<head\s+.+?>).+<\/head>/is', '<head></head>', $this->html);
         $this->setHtml($html);
         return $this->ql;
     }


### PR DESCRIPTION
Fix the matching exception when the page contains multiple tags prefixed with head (for example: < head >, < header >)