### PR TITLE
正则匹配成功时才替换掉html

### DIFF
--- a/src/Dom/Query.php
+++ b/src/Dom/Query.php
@@ -125,8 +125,8 @@ class Query
      */
     public function removeHead()
     {
-        $html = preg_replace('/(<head>|<head\s+.+?>).+<\/head>/is', '<head></head>', $this->html);
-        $this->setHtml($html);
+        $html = preg_replace('/(<head>|<head\s+.+?>).+?<\/head>/is', '<head></head>', $this->html);
+        $html && $this->setHtml($html);
         return $this->ql;
     }
 


### PR DESCRIPTION
例如
https://www.amazon.com//TCL-40S325-Inch-1080p-Smart/dp/B07GB61TQR/ref=sr_1_2?dchild=1&amp;keywords=televison&amp;qid=1625562976&amp;refinements=p_n_availability%3A2661601011&amp;rnid=2661599011&amp;sr=8-2
这个页面,正则匹配就会异常,导致正则替换后的$html为null