### PR TITLE
Collection.php error: [ParseError] syntax error, unexpected '=>' (T_D…

### DIFF
--- a/src/Collect/Support/Collection.php
+++ b/src/Collect/Support/Collection.php
@@ -498,11 +498,14 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
             }
 
             foreach ($groupKeys as $groupKey) {
-                $groupKey = match (true) {
-                    is_bool($groupKey) => (int) $groupKey,
-                    $groupKey instanceof \Stringable => (string) $groupKey,
-                    default => $groupKey,
-                };
+                
+                if (is_bool($groupKey)) {
+                    $groupKey = (int) $groupKey;
+                } elseif ($groupKey instanceof \Stringable) {
+                    $groupKey = (string) $groupKey;
+                } else {
+                    // No transformation needed
+                }
 
                 if (! array_key_exists($groupKey, $results)) {
                     $results[$groupKey] = new static;


### PR DESCRIPTION
…OUBLE_ARROW) in       vendor/jaeger/querylist/src/Collect/Support/Collection.php on line 502

Library states, that is 7.2 compatible, and yet it uses php8 match() function.  This should make the code backwards compatible (?)