### PR TITLE
feat: add Swiftproxy sponsor link

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -145,7 +145,7 @@ $ql = QueryList::get('http://weibo.com','param1=testvalue & params2=somevalue',[
 echo $ql->find('title')->text();
 //输出: 我的首页 微博-随时随地发现新鲜事
 ```
-- 使用Http代理 (如果你正在寻找代理服务，这里有一个 [HTTP proxy provider](https://www.swiftproxy.net/?ref=QueryList) 可以看看)
+- 使用Http代理 (如果你正在寻找代理服务，这里有一个 [HTTP 代理提供商](https://www.swiftproxy.net/?ref=QueryList) 可以看看)
 ```php
 $urlParams = ['param1' => 'testvalue','params2' => 'somevalue'];
 $opts = [

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -145,7 +145,7 @@ $ql = QueryList::get('http://weibo.com','param1=testvalue & params2=somevalue',[
 echo $ql->find('title')->text();
 //输出: 我的首页 微博-随时随地发现新鲜事
 ```
-- 使用Http代理 (If you are looking for proxies to use, here is a [HTTP proxy provider](https://www.swiftproxy.net/?ref=QueryList) that you can take a look at.)
+- 使用Http代理 (如果你正在寻找代理服务，这里有一个 [HTTP proxy provider](https://www.swiftproxy.net/?ref=QueryList) 可以看看)
 ```php
 $urlParams = ['param1' => 'testvalue','params2' => 'somevalue'];
 $opts = [

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -145,7 +145,7 @@ $ql = QueryList::get('http://weibo.com','param1=testvalue & params2=somevalue',[
 echo $ql->find('title')->text();
 //输出: 我的首页 微博-随时随地发现新鲜事
 ```
-- 使用Http代理
+- 使用Http代理 (If you are looking for proxies to use, here is a [HTTP proxy provider](https://www.swiftproxy.net/?ref=QueryList) that you can take a look at.)
 ```php
 $urlParams = ['param1' => 'testvalue','params2' => 'somevalue'];
 $opts = [

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ $ql = QueryList::get('https://github.com','param1=testvalue & params2=somevalue'
 $userName = $ql->find('.header-nav-current-user>.css-truncate-target')->text();
 echo $userName;
 ```
-- Use the Http proxy
+- Use the Http proxy (If you are looking for proxies to use, here is a [HTTP proxy provider](https://www.swiftproxy.net/?ref=QueryList) that you can take a look at.)
 ```php
 $urlParams = ['param1' => 'testvalue','params2' => 'somevalue'];
 $opts = [


### PR DESCRIPTION
## Summary
Add Swiftproxy sponsor link to HTTP proxy section in both English and Chinese README.

## Changes
- README.md: Added sponsor link after "Use the Http proxy"
- README-ZH.md: Added sponsor link after "使用Http代理"

## Sponsor Info
- Service: Swiftproxy (Residential proxy provider)
- Ref: QueryList
- URL: https://www.swiftproxy.net/?ref=QueryList

Closes: N/A (new sponsor partnership)