### PR TITLE
Remove Swiftproxy advertisement from READMEs

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -149,7 +149,7 @@ $ql = QueryList::get('http://weibo.com','param1=testvalue & params2=somevalue',[
 echo $ql->find('title')->text();
 //输出: 我的首页 微博-随时随地发现新鲜事
 ```
-- 使用Http代理 (如果你正在寻找代理服务，这里有一个 [HTTP 代理提供商](https://www.swiftproxy.net/?ref=QueryList) 可以看看)
+- 使用Http代理
 ```php
 $urlParams = ['param1' => 'testvalue','params2' => 'somevalue'];
 $opts = [

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ $ql = QueryList::get('https://github.com','param1=testvalue & params2=somevalue'
 $userName = $ql->find('.header-nav-current-user>.css-truncate-target')->text();
 echo $userName;
 ```
-- Use the Http proxy (If you are looking for proxies to use, here is a [HTTP proxy provider](https://www.swiftproxy.net/?ref=QueryList) that you can take a look at.)
+- Use the Http proxy
 ```php
 $urlParams = ['param1' => 'testvalue','params2' => 'somevalue'];
 $opts = [


### PR DESCRIPTION
从 README.md 和 README-ZH.md 中移除 Swiftproxy 代理服务的广告链接，保持文档简洁。